### PR TITLE
Ticket #35 - View Reactions On a Post

### DIFF
--- a/TabloidFullStack/TabloidFullStack/Controllers/PostReactionController.cs
+++ b/TabloidFullStack/TabloidFullStack/Controllers/PostReactionController.cs
@@ -36,6 +36,13 @@ namespace TabloidFullStack.Controllers
             return NoContent();
         }
 
+        [HttpDelete("{id}")]
+        public IActionResult Delete(int id)
+        {
+            _postReactionRepository.Delete(id);
+            return NoContent();
+        }
+
         //// GET: api/<PostReactionController>
         //[HttpGet]
         //public IEnumerable<string> Get()

--- a/TabloidFullStack/TabloidFullStack/Repositories/IPostReactionRepository.cs
+++ b/TabloidFullStack/TabloidFullStack/Repositories/IPostReactionRepository.cs
@@ -7,5 +7,6 @@ namespace TabloidFullStack.Repositories
         List<PostReaction> GetAll();
         List<PostReaction> GetByPostId(int postId);
         void Add(PostReaction postreaction);
+        void Delete(int reactionId);
     }
 }

--- a/TabloidFullStack/TabloidFullStack/Repositories/PostReactionRepository.cs
+++ b/TabloidFullStack/TabloidFullStack/Repositories/PostReactionRepository.cs
@@ -1,4 +1,5 @@
-﻿using TabloidFullStack.Models;
+﻿using Microsoft.Data.SqlClient;
+using TabloidFullStack.Models;
 using TabloidFullStack.Utils;
 
 namespace TabloidFullStack.Repositories
@@ -87,6 +88,26 @@ namespace TabloidFullStack.Repositories
                     cmd.Parameters.AddWithValue("@UserProfileId", postreaction.UserProfileId);
 
                     postreaction.Id = (int)cmd.ExecuteScalar();
+                }
+            }
+        }
+
+        public void Delete(int reactionId)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                            DELETE from PostReaction
+                            WHERE Id = @id
+                        ";
+
+                    cmd.Parameters.AddWithValue("@id", reactionId);
+
+                    cmd.ExecuteNonQuery();
                 }
             }
         }

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/Managers/PostReactionManager.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/Managers/PostReactionManager.js
@@ -29,3 +29,7 @@ export const getpostreactionsbypostid = (postid) => {
       body: JSON.stringify(postReaction),
     });
   };  
+
+  export const deletePostReaction = (id) => {
+    return fetch(`https://localhost:5001/api/postreaction/${id}`, { method: "DELETE" })
+  }

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/ApplicationViews.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/ApplicationViews.js
@@ -7,9 +7,9 @@ import UserPostList from "./posts/MyPostList";
 import UserProfileDetails from "./UserProfiles/UserProfileDetails";
 import PostDetails from "./posts/PostDetails";
 import PostForm from "./posts/PostForm";
-import { CategoryList } from "./Categories/CategoryList";
-import CategoryForm from "./Categories/CategoryForm";
-import { EditCategory } from "./Categories/CategoryEdit";
+import { CategoryList } from "./categories/CategoryList";
+import CategoryForm from "./categories/CategoryForm";
+import { EditCategory } from "./categories/CategoryEdit";
 
 
 export default function ApplicationViews() {

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/posts/PostReaction.js
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/components/posts/PostReaction.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { addPostReaction, getpostreactionsbypostid } from "../../Managers/PostReactionManager";
+import { addPostReaction, deletePostReaction, getpostreactionsbypostid } from "../../Managers/PostReactionManager";
 
 export const PostReaction = ({ post, reaction }) => {
     const localTabloidUser = localStorage.getItem("userProfile");
@@ -36,14 +36,11 @@ export const PostReaction = ({ post, reaction }) => {
         window.location.reload();
       };
     
-    const buttonChange = () => {
-        if (reactionCount.length === 0 || userReactionCount.length === 0) {
-            return <button className="btn btn-secondary m-1" onClick={addReaction}><img className="reaction-btn" alt="" src={reaction.imageLocation} /> {reactionCount.length} </button>  
-        }
-        else {
-            return <button className="btn btn-secondary m-1" onClick={addReaction}><img className="reaction-btn" alt="" src={reaction.imageLocation} /> {reactionCount.length} </button>
-        }
-    };
+    const deleteReaction = () => {
+        deletePostReaction(userReactionCount[0].id);
+        window.location.reload();
+
+    }
 
     const userReactionCount = postReactionsList.filter((pr) => pr.userProfileId === tabloidUserObject.id && pr.reactionId === reaction.id);
     const reactionCount = postReactionsList.filter((pr) => pr.reactionId === reaction.id);
@@ -58,7 +55,7 @@ export const PostReaction = ({ post, reaction }) => {
                 </button>
             </>
         ) : (
-            <button className="btn btn-primary m-1" >
+            <button className="btn btn-primary m-1" id="reacted" onClick={deleteReaction}>
             <img className="reaction-btn" alt={reaction.name} src={reaction.imageLocation} />
             <br />
             <span className="h6 m-3">{reactionCount.length}</span>

--- a/TabloidFullStack/TabloidFullStack/client/tabloid/src/index.css
+++ b/TabloidFullStack/TabloidFullStack/client/tabloid/src/index.css
@@ -27,3 +27,7 @@ code {
   width: 3.5rem;
   border-radius: 1rem;
 }
+
+#reacted:hover {
+  background-color: rgba(255, 0, 0, 0.442);
+}


### PR DESCRIPTION
**Description**
This code adds a new feature - viewing reactions to posts from the post details page. A list of images is present on every post details page just below the content of the post, along with a count of how many different users have reacted to the post with that reaction. This code also adds an additional feature which wasn't outlined in a ticket specifically, which is the ability for a user to remove any of their reactions from a post.

**Related Ticket(s)**
https://trello.com/c/6XcpIN90/35-35-view-reactions-on-a-post

Ticket #35 - View Reactions on a Post

**Type of Change**

- [X] New feature (non-breaking change which adds functionality)

**Testing Instructions**

- Clone this project’s repository to your machine
  -If you’ve already done this and are currently working on a different branch of the project, be sure to `git add` and `git commit` whatever you’re working on on your branch, before you attempt to switch branches
  -Then `git checkout main` to switch to the project’s main branch)
- Navigate to the root directory for this repo (yourParentFolderName/tabloidfullstack-the-cage-crushers)
- `git fetch -a` to retrieve the current remote-tracked branches for the project, you should see a branch named `cm-viewpostreaction` as one of the available branches
- `git checkout cm-viewpostreaction` to switch to my branch
- If you don't see the most recent version of my files, `git pull origin cm-viewpostreaction`
- `Start TabloidFullStack.sln` to open the project in Visual Studio
- If you haven’t created the Tabloid database, please do so in Visual Studio and use the following SQL scripts to populate it accordingly:
  - Start a new query in your database and copy in this SQL script before running to fill out tables and columns: [First SQL Script for Creating DB](https://github.com/NewForce-Cohort-8/tabloidfullstack-the-cage-crushers/blob/main/SQL/01_Tabloid_Create_DB.sql)
  - ctrl + a and delete what is in that query and replace it with this SQL script before running to seed the database: [Second SQL Script for Seeding DB](https://github.com/NewForce-Cohort-8/tabloidfullstack-the-cage-crushers/blob/main/SQL/02_Tabloid_Seed_Data.sql)

- **If you didn't already seed your reactions database while testing the pull request for ticket #34, you will also need to run another SQL query to add reactions to your database!** Here is the SQL code to run to create 5 different reactions that will be available as buttons below each post on their respective post details page:

```
insert into Reaction ([Name], ImageLocation) values ('LIKE', 'https://cdn5.vectorstock.com/i/1000x1000/81/79/i-like-it-rubber-stamp-vector-15968179.jpg');
insert into Reaction ([Name], ImageLocation) values ('LOVE', 'https://images.unsplash.com/photo-1516589178581-6cd7833ae3b2?q=80&w=1000&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8bG92ZSUyMGhlYXJ0fGVufDB8fDB8fHww');
insert into Reaction ([Name], ImageLocation) values ('DONTCARE', 'https://wallpapers.com/images/featured/i-dont-care-g18m8or32x2e6f7h.jpg');
insert into Reaction ([Name], ImageLocation) values ('HATE', 'https://images.lookhuman.com/render/standard/EPp7V7xG67RTCvgtQ32UOt1KuiPVfjCF/diecut-whi-lg-t-thanks-i-hate-it.jpg');
insert into Reaction ([Name], ImageLocation) values ('SHRUG', 'https://pbs.twimg.com/media/E9vAgSkXMAQWMOq.png');
```

- Click the execute with debugger solid green button to launch the app
- You should be directed to the /login page and prompted to login - enter “[foo@bar.com](mailto:foo@bar.com)” in the email field and click “Login” - this should redirect you back to the home page.
- Click the “Posts” link/option on the nav bar to get to the Posts page
- Click the post titled "productize turn-key convergence" to be taken to that post's details page. Alternatively, manually direct your browser to /posts/7 to reach that same page.
- Once on that post's details page, scroll down to the bottom of the post where you should now see 5 different icon buttons below the post's published date.
- If you tested the pull request for ticket #34, all of the post reaction buttons should have a blue background and the number 1 just below their respective images.
  - If you didn't test the pull request for ticket #34, simply click each of the post reaction buttons. As you click them, their background should change from gray to blue and the number below their image should change from 0 to 1. This will also add a new row of data to the PostReactions table of your database - storing the logged in user's profile id, the current post's id, and the reaction's id number.
- One by one, click each of the post reaction buttons - they should start with a blue background and a number one below them before you click them, the background color should change to a pinkish/red color as you hover over the button but before you click them, and then after you click them they should revert back to a gray background and the number zero below them. This will also delete the row of data from the PostReactions table that was added when you clicked to add the post reaction to the post.
- Once you've clicked all of the post reaction buttons on this post so they all have a gray background again and the numbers below them are 0, run this SQL command and verify that there are 0 entries in  your PostReaction database.
```
SELECT * FROM PostReaction
WHERE PostId = 7
```

Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [X] I have added test instructions that prove my fix is effective or that my feature works